### PR TITLE
Review Clippy Warnings

### DIFF
--- a/src/atomics.rs
+++ b/src/atomics.rs
@@ -75,10 +75,28 @@ impl<T: 'static> AtomicArc<T, StandardReclaimer> {
 }
 
 impl<T: 'static, R: Protect + Retire> AtomicArc<T, R> {
-    /// If `self` and `current` point to the same allocation, `new`'s pointer will be stored into
-    /// `self` and the result will be an empty [`Ok`]. Otherwise, an [`Err`] containing the
-    /// previous value will be returned.
-    #[allow(clippy::missing_errors_doc)]
+    /// Stores a value into the pointer if the current value is the same as the `current` value.
+    ///
+    /// This method provides guarded access to the `compare_exchange` method from the [`AtomicPtr<T>`]
+    /// held internally by [`AtomicArc<T>`].
+    ///
+    /// ### Arguments
+    /// `compare_exchange` takes in two [`SmartPtr<T>`] references as arguments:
+    /// - `current`: This reference should match the actual value inside [`AtomicArc<T>`] for success.
+    /// - `new`: A reference to the new value for [`AtomicArc<T>`].
+    ///
+    /// ### Results
+    /// The internal pointer of [`AtomicArc<T>`] is updated to the same location as the
+    /// supplied by the `new` [`SmartPtr<T>`]. On success the [`Ok`] unit value is returned.
+    ///
+    /// ### Notes
+    /// - see the [`compare_exchange`] method of [`std::sync::atomic::AtomicPtr`] for more info.
+    ///
+    /// # Errors
+    /// If the `current` and the actual allocations do not match, an [`Err`] containing the
+    /// 'new' [`SmartPtr<T>`] in the same form as supplied.
+    ///
+    /// [`compare_exchange`]: std::sync::atomic::AtomicPtr::compare_exchange
     pub fn compare_exchange<C, N, V>(
         &self,
         current: Option<&C>,
@@ -210,9 +228,30 @@ pub struct AtomicWeak<T: 'static, R: Protect + Retire = StandardReclaimer> {
 }
 
 impl<T: 'static, R: Protect + Retire> AtomicWeak<T, R> {
-    /// See [`AtomicArc::compare_exchange`]. This method behaves similarly, except that the return
-    /// type for the failure case cannot be specified by the caller; it will be a [`Weak`].
-    #[allow(clippy::missing_errors_doc)]
+    /// Stores a value into the pointer if the current value is the same as the `current` value.
+    ///
+    /// This method provides guarded access to the `compare_exchange` method from the [`AtomicPtr<T>`]
+    /// held internally by [`AtomicWeak<T>`].
+    ///
+    /// ### Arguments
+    /// `compare_exchange` takes in two [`SmartPtr<T>`] references as arguments:
+    /// - `current`: This reference should match the actual value inside [`AtomicWeak<T>`] for success.
+    /// - `new`: A reference to the new value for [`AtomicWeak<T>`].
+    ///
+    /// ### Results
+    /// The internal pointer of [`AtomicWeak<T>`] is updated to the same location as the
+    /// supplied by the `new` [`SmartPtr<T>`]. On success the [`Ok`] unit value is returned.
+    ///
+    /// ### Notes
+    /// - see the [`compare_exchange`] method of [`std::sync::atomic::AtomicPtr`] for more info.
+    /// - this method is _not_ analogous to the [`compare_exchange_weak`] method of [`AtomicPtr`].
+    ///
+    /// # Errors
+    /// If the `current` and the actual allocations do not match, an [`Err`] containing the
+    /// 'new' [`SmartPtr<T>`] downgraded into a [`std::sync::Weak<T>`].
+    ///
+    /// [`compare_exchange`]: std::sync::atomic::AtomicPtr::compare_exchange
+    /// [`compare_exchange_weak`]: std::sync::atomic::AtomicPtr::compare_exchange_weak
     pub fn compare_exchange<C, N>(
         &self,
         current: Option<&C>,

--- a/src/atomics.rs
+++ b/src/atomics.rs
@@ -78,6 +78,7 @@ impl<T: 'static, R: Protect + Retire> AtomicArc<T, R> {
     /// If `self` and `current` point to the same allocation, `new`'s pointer will be stored into
     /// `self` and the result will be an empty [`Ok`]. Otherwise, an [`Err`] containing the
     /// previous value will be returned.
+    #[allow(clippy::missing_errors_doc)]
     pub fn compare_exchange<C, N, V>(
         &self,
         current: Option<&C>,
@@ -113,6 +114,7 @@ impl<T: 'static, R: Protect + Retire> AtomicArc<T, R> {
         };
         drop(guard); // drop it early because retire could take a (relatively) long time.
         if !to_retire.is_null() {
+            #[allow(clippy::ptr_as_ptr)]
             R::retire(to_retire as *mut u8, get_drop_fn::<T, true>());
         }
         result
@@ -140,6 +142,7 @@ impl<T: 'static, R: Protect + Retire> AtomicArc<T, R> {
         }
         let before = self.ptr.swap(ptr.cast_mut(), AcqRel);
         if !before.is_null() {
+            #[allow(clippy::ptr_as_ptr)]
             R::retire(before as *mut u8, get_drop_fn::<T, true>());
         }
     }
@@ -176,6 +179,7 @@ impl<T: 'static, R: Protect + Retire> Drop for AtomicArc<T, R> {
     fn drop(&mut self) {
         let ptr = self.ptr.load(Relaxed);
         if !ptr.is_null() {
+            #[allow(clippy::ptr_as_ptr)]
             R::retire(ptr as *mut u8, get_drop_fn::<T, true>());
         }
     }
@@ -211,6 +215,7 @@ pub struct AtomicWeak<T: 'static, R: Protect + Retire = StandardReclaimer> {
 impl<T: 'static, R: Protect + Retire> AtomicWeak<T, R> {
     /// See [`AtomicArc::compare_exchange`]. This method behaves similarly, except that the return
     /// type for the failure case cannot be specified by the caller; it will be a [`Weak`].
+    #[allow(clippy::missing_errors_doc)]
     pub fn compare_exchange<C, N>(
         &self,
         current: Option<&C>,
@@ -245,6 +250,7 @@ impl<T: 'static, R: Protect + Retire> AtomicWeak<T, R> {
         };
         drop(guard); // drop it early because retire could take a (relatively) long time.
         if !to_retire.is_null() {
+            #[allow(clippy::ptr_as_ptr)]
             R::retire(to_retire as *mut u8, get_drop_fn::<T, false>());
         }
         result
@@ -271,6 +277,7 @@ impl<T: 'static, R: Protect + Retire> AtomicWeak<T, R> {
         }
         let before = self.ptr.swap(ptr.cast_mut(), AcqRel);
         if !before.is_null() {
+            #[allow(clippy::ptr_as_ptr)]
             R::retire(before as *mut u8, get_drop_fn::<T, false>());
         }
     }
@@ -316,6 +323,7 @@ impl<T: 'static, R: Protect + Retire> Drop for AtomicWeak<T, R> {
     fn drop(&mut self) {
         let ptr = self.ptr.load(Relaxed);
         if !ptr.is_null() {
+            #[allow(clippy::ptr_as_ptr)]
             R::retire(ptr as *mut u8, get_drop_fn::<T, false>());
         }
     }

--- a/src/atomics.rs
+++ b/src/atomics.rs
@@ -463,6 +463,7 @@ impl<T> AsPtr<T> for Weak<T> {
 }
 
 pub trait CloneFromRaw<T> {
+    // Todo: add safety documentation for this trait-function.
     #[allow(clippy::missing_safety_doc)]
     unsafe fn clone_from_raw(ptr: *const T) -> Self;
 }

--- a/src/atomics.rs
+++ b/src/atomics.rs
@@ -114,8 +114,7 @@ impl<T: 'static, R: Protect + Retire> AtomicArc<T, R> {
         };
         drop(guard); // drop it early because retire could take a (relatively) long time.
         if !to_retire.is_null() {
-            #[allow(clippy::ptr_as_ptr)]
-            R::retire(to_retire as *mut u8, get_drop_fn::<T, true>());
+            R::retire(to_retire.cast::<u8>(), get_drop_fn::<T, true>());
         }
         result
     }
@@ -142,8 +141,7 @@ impl<T: 'static, R: Protect + Retire> AtomicArc<T, R> {
         }
         let before = self.ptr.swap(ptr.cast_mut(), AcqRel);
         if !before.is_null() {
-            #[allow(clippy::ptr_as_ptr)]
-            R::retire(before as *mut u8, get_drop_fn::<T, true>());
+            R::retire(before.cast::<u8>(), get_drop_fn::<T, true>());
         }
     }
 }
@@ -179,8 +177,7 @@ impl<T: 'static, R: Protect + Retire> Drop for AtomicArc<T, R> {
     fn drop(&mut self) {
         let ptr = self.ptr.load(Relaxed);
         if !ptr.is_null() {
-            #[allow(clippy::ptr_as_ptr)]
-            R::retire(ptr as *mut u8, get_drop_fn::<T, true>());
+            R::retire(ptr.cast::<u8>(), get_drop_fn::<T, true>());
         }
     }
 }
@@ -250,8 +247,7 @@ impl<T: 'static, R: Protect + Retire> AtomicWeak<T, R> {
         };
         drop(guard); // drop it early because retire could take a (relatively) long time.
         if !to_retire.is_null() {
-            #[allow(clippy::ptr_as_ptr)]
-            R::retire(to_retire as *mut u8, get_drop_fn::<T, false>());
+            R::retire(to_retire.cast::<u8>(), get_drop_fn::<T, false>());
         }
         result
     }
@@ -277,8 +273,7 @@ impl<T: 'static, R: Protect + Retire> AtomicWeak<T, R> {
         }
         let before = self.ptr.swap(ptr.cast_mut(), AcqRel);
         if !before.is_null() {
-            #[allow(clippy::ptr_as_ptr)]
-            R::retire(before as *mut u8, get_drop_fn::<T, false>());
+            R::retire(before.cast::<u8>(), get_drop_fn::<T, false>());
         }
     }
 
@@ -323,8 +318,7 @@ impl<T: 'static, R: Protect + Retire> Drop for AtomicWeak<T, R> {
     fn drop(&mut self) {
         let ptr = self.ptr.load(Relaxed);
         if !ptr.is_null() {
-            #[allow(clippy::ptr_as_ptr)]
-            R::retire(ptr as *mut u8, get_drop_fn::<T, false>());
+            R::retire(ptr.cast::<u8>(), get_drop_fn::<T, false>());
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,3 @@ pub(crate) mod utils {
     pub(crate) mod unrolled_linked_list;
     pub(crate) mod unsafe_arc;
 }
-
-// Todo:
-// - Review Ignored Clippy Warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,6 @@ pub(crate) mod utils {
     pub(crate) mod unrolled_linked_list;
     pub(crate) mod unsafe_arc;
 }
+
+// Todo:
+// - Review Ignored Clippy Warnings

--- a/src/smr/standard_reclaimer.rs
+++ b/src/smr/standard_reclaimer.rs
@@ -235,8 +235,7 @@ struct Batch {
 
 impl Drop for Batch {
     fn drop(&mut self) {
-        #[allow(clippy::explicit_iter_loop)]
-        for (ptr, f) in self.functions.iter() {
+        for (ptr, f) in &self.functions {
             (*f)(*ptr);
         }
     }

--- a/src/smr/standard_reclaimer.rs
+++ b/src/smr/standard_reclaimer.rs
@@ -267,8 +267,7 @@ mod tests {
     fn with_flag<F: Fn(*mut Cell<bool>, fn(*mut u8))>(f: F) {
         let flag_ptr = alloc_box_ptr(Cell::new(false));
         let flag_fn = Box::new(|ptr: *mut u8| unsafe {
-            #[allow(clippy::ptr_as_ptr)]
-            (*(ptr as *mut Cell<bool>)).set(true);
+            (*ptr.cast::<Cell<bool>>()).set(true);
         });
         f(flag_ptr, *flag_fn);
         unsafe {
@@ -293,8 +292,7 @@ mod tests {
             let slot = StandardReclaimer::get_or_claim_slot();
             let guard = StandardReclaimer::protect();
 
-            #[allow(clippy::ptr_as_ptr)]
-            StandardReclaimer::retire(flag_ptr as *mut u8, flag_fn);
+            StandardReclaimer::retire(flag_ptr.cast::<u8>(), flag_fn);
             assert!(!(*flag_ptr).get());
 
             drop(guard);
@@ -322,11 +320,9 @@ mod tests {
                 ptrs: HashSet::with_capacity(1),
             });
 
-            #[allow(clippy::ptr_as_ptr)]
-            let guard = StandardReclaimer::protect_ptr(flag_ptr as *mut u8);
+            let guard = StandardReclaimer::protect_ptr(flag_ptr.cast::<u8>());
 
-            #[allow(clippy::ptr_as_ptr)]
-            StandardReclaimer::retire(flag_ptr as *mut u8, flag_fn);
+            StandardReclaimer::retire(flag_ptr.cast::<u8>(), flag_fn);
             assert!(!(*flag_ptr).get());
 
             drop(guard);

--- a/src/smr/standard_reclaimer.rs
+++ b/src/smr/standard_reclaimer.rs
@@ -44,6 +44,7 @@ impl StandardReclaimer {
         SLOTS.get_or_init(UnrolledLinkedList::default)
     }
     thread_local! {
+        #[allow(clippy::default_trait_access)]
         static SLOT_HANDLE: RefCell<SlotHandle> = Default::default();
     }
     fn get_or_claim_slot() -> &'static Slot {
@@ -122,6 +123,7 @@ impl Retire for StandardReclaimer {
         }
         let all_slots = Self::get_all_slots();
         let next_batch_size = all_slots.get_nodes_count() * SLOTS_PER_NODE;
+        #[allow(clippy::explicit_deref_methods)]
         let batch = mem::replace(
             borrowed.deref_mut(),
             Batch {
@@ -224,15 +226,16 @@ impl Drop for CollectionNode {
     }
 }
 
-#[allow(clippy::type_complexity)]
 #[derive(Default)]
 struct Batch {
+    #[allow(clippy::type_complexity)]
     functions: Vec<(*mut u8, fn(*mut u8))>,
     ptrs: HashSet<*mut u8>,
 }
 
 impl Drop for Batch {
     fn drop(&mut self) {
+        #[allow(clippy::explicit_iter_loop)]
         for (ptr, f) in self.functions.iter() {
             (*f)(*ptr);
         }
@@ -264,6 +267,7 @@ mod tests {
     fn with_flag<F: Fn(*mut Cell<bool>, fn(*mut u8))>(f: F) {
         let flag_ptr = alloc_box_ptr(Cell::new(false));
         let flag_fn = Box::new(|ptr: *mut u8| unsafe {
+            #[allow(clippy::ptr_as_ptr)]
             (*(ptr as *mut Cell<bool>)).set(true);
         });
         f(flag_ptr, *flag_fn);
@@ -289,6 +293,7 @@ mod tests {
             let slot = StandardReclaimer::get_or_claim_slot();
             let guard = StandardReclaimer::protect();
 
+            #[allow(clippy::ptr_as_ptr)]
             StandardReclaimer::retire(flag_ptr as *mut u8, flag_fn);
             assert!(!(*flag_ptr).get());
 
@@ -317,8 +322,10 @@ mod tests {
                 ptrs: HashSet::with_capacity(1),
             });
 
+            #[allow(clippy::ptr_as_ptr)]
             let guard = StandardReclaimer::protect_ptr(flag_ptr as *mut u8);
 
+            #[allow(clippy::ptr_as_ptr)]
             StandardReclaimer::retire(flag_ptr as *mut u8, flag_fn);
             assert!(!(*flag_ptr).get());
 

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -2,6 +2,7 @@ pub(crate) fn alloc_box_ptr<T>(item: T) -> *mut T {
     Box::into_raw(Box::new(item))
 }
 
+#[allow(clippy::semicolon_if_nothing_returned)]
 pub(crate) unsafe fn dealloc_box_ptr<T>(ptr: *mut T) {
     drop(Box::from_raw(ptr))
 }

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -2,7 +2,6 @@ pub(crate) fn alloc_box_ptr<T>(item: T) -> *mut T {
     Box::into_raw(Box::new(item))
 }
 
-#[allow(clippy::semicolon_if_nothing_returned)]
 pub(crate) unsafe fn dealloc_box_ptr<T>(ptr: *mut T) {
-    drop(Box::from_raw(ptr))
+    drop(Box::from_raw(ptr));
 }

--- a/src/utils/unrolled_linked_list.rs
+++ b/src/utils/unrolled_linked_list.rs
@@ -35,6 +35,7 @@ impl<T: Default, const N: usize> UnrolledLinkedList<T, N> {
     pub(crate) fn try_for_each_with_append<F: Fn(&T) -> bool>(&self, f: F) -> &T {
         let mut curr = &self.head;
         loop {
+            #[allow(clippy::explicit_iter_loop)]
             for item in curr.items.iter() {
                 if f(item) {
                     return item;

--- a/src/utils/unrolled_linked_list.rs
+++ b/src/utils/unrolled_linked_list.rs
@@ -35,8 +35,7 @@ impl<T: Default, const N: usize> UnrolledLinkedList<T, N> {
     pub(crate) fn try_for_each_with_append<F: Fn(&T) -> bool>(&self, f: F) -> &T {
         let mut curr = &self.head;
         loop {
-            #[allow(clippy::explicit_iter_loop)]
-            for item in curr.items.iter() {
+            for item in &curr.items {
                 if f(item) {
                     return item;
                 }

--- a/src/utils/unsafe_arc.rs
+++ b/src/utils/unsafe_arc.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use std::sync::atomic::{fence, AtomicUsize};
 
 /// A slightly more efficient and convenient Arc for internal use only.
+#[allow(clippy::doc_markdown)]
 /// It has no weak count, implements DerefMut, and can be initialized with an arbitrary ref count.
 pub(crate) struct UnsafeArc<T> {
     ptr: NonNull<UnsafeArcInner<T>>,
@@ -13,11 +14,13 @@ pub(crate) struct UnsafeArc<T> {
 }
 
 impl<T> UnsafeArc<T> {
+    #[allow(clippy::ptr_as_ptr)]
     pub(crate) fn as_ptr(this: &Self) -> *mut T {
         this.ptr.as_ptr() as *mut T
     }
     pub(crate) unsafe fn decrement_ref_count(ptr: *mut T) {
         unsafe {
+            #[allow(clippy::ptr_as_ptr)]
             let inner = ptr as *mut UnsafeArcInner<T>;
             if (*inner).ref_count.fetch_sub(1, Release) == 1 {
                 fence(Acquire);
@@ -27,6 +30,7 @@ impl<T> UnsafeArc<T> {
     }
     pub(crate) unsafe fn from_raw(ptr: *mut T) -> Self {
         Self {
+            #[allow(clippy::ptr_as_ptr)]
             ptr: NonNull::new_unchecked(ptr as *mut UnsafeArcInner<T>),
             phantom: PhantomData,
         }

--- a/src/utils/unsafe_arc.rs
+++ b/src/utils/unsafe_arc.rs
@@ -14,14 +14,12 @@ pub(crate) struct UnsafeArc<T> {
 }
 
 impl<T> UnsafeArc<T> {
-    #[allow(clippy::ptr_as_ptr)]
     pub(crate) fn as_ptr(this: &Self) -> *mut T {
-        this.ptr.as_ptr() as *mut T
+        this.ptr.as_ptr().cast::<T>()
     }
     pub(crate) unsafe fn decrement_ref_count(ptr: *mut T) {
         unsafe {
-            #[allow(clippy::ptr_as_ptr)]
-            let inner = ptr as *mut UnsafeArcInner<T>;
+            let inner = ptr.cast::<UnsafeArcInner<T>>();
             if (*inner).ref_count.fetch_sub(1, Release) == 1 {
                 fence(Acquire);
                 dealloc_box_ptr(inner);
@@ -30,8 +28,7 @@ impl<T> UnsafeArc<T> {
     }
     pub(crate) unsafe fn from_raw(ptr: *mut T) -> Self {
         Self {
-            #[allow(clippy::ptr_as_ptr)]
-            ptr: NonNull::new_unchecked(ptr as *mut UnsafeArcInner<T>),
+            ptr: NonNull::new_unchecked(ptr.cast::<UnsafeArcInner<T>>()),
             phantom: PhantomData,
         }
     }

--- a/src/utils/unsafe_arc.rs
+++ b/src/utils/unsafe_arc.rs
@@ -6,8 +6,7 @@ use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use std::sync::atomic::{fence, AtomicUsize};
 
 /// A slightly more efficient and convenient Arc for internal use only.
-#[allow(clippy::doc_markdown)]
-/// It has no weak count, implements DerefMut, and can be initialized with an arbitrary ref count.
+/// It has no weak count, implements `DerefMut`, and can be initialized with an arbitrary ref count.
 pub(crate) struct UnsafeArc<T> {
     ptr: NonNull<UnsafeArcInner<T>>,
     phantom: PhantomData<UnsafeArcInner<T>>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25,6 +25,7 @@ fn test_stack(threads_count: usize, iters_per_thread: usize) {
                     next: top.as_ref().map(Arc::from),
                 });
                 match self.top.compare_exchange(top.as_ref(), Some(&new_node)) {
+                    #[allow(clippy::ignored_unit_patterns)]
                     Ok(_) => break,
                     Err(before) => top = before,
                 }
@@ -37,6 +38,7 @@ fn test_stack(threads_count: usize, iters_per_thread: usize) {
                     .top
                     .compare_exchange(top.as_ref(), top_node.next.as_ref())
                 {
+                    #[allow(clippy::ignored_unit_patterns)]
                     Ok(_) => return top,
                     Err(actual_top) => top = actual_top,
                 }
@@ -72,6 +74,7 @@ fn test_stack(threads_count: usize, iters_per_thread: usize) {
     });
 
     // Verify that no nodes were lost.
+    #[allow(clippy::explicit_iter_loop)]
     for count in val_counts.iter() {
         assert_eq!(count.load(SeqCst), threads_count);
     }
@@ -112,6 +115,7 @@ fn test_sorted_linked_list(threads_count: usize, iters_per_thread: usize) {
                         next: next.as_ref().map_or(AtomicArc::default(), AtomicArc::from),
                     });
                     match curr_node.next.compare_exchange(next.as_ref(), Some(&new)) {
+                        #[allow(clippy::ignored_unit_patterns)]
                         Ok(_) => {
                             if let Some(next_node) = next {
                                 // This is technically incorrect; another node could've been

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -74,8 +74,8 @@ fn test_stack(threads_count: usize, iters_per_thread: usize) {
     });
 
     // Verify that no nodes were lost.
-    #[allow(clippy::explicit_iter_loop)]
-    for count in val_counts.iter() {
+
+    for count in &val_counts {
         assert_eq!(count.load(SeqCst), threads_count);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -25,8 +25,7 @@ fn test_stack(threads_count: usize, iters_per_thread: usize) {
                     next: top.as_ref().map(Arc::from),
                 });
                 match self.top.compare_exchange(top.as_ref(), Some(&new_node)) {
-                    #[allow(clippy::ignored_unit_patterns)]
-                    Ok(_) => break,
+                    Ok(()) => break,
                     Err(before) => top = before,
                 }
             }
@@ -38,8 +37,7 @@ fn test_stack(threads_count: usize, iters_per_thread: usize) {
                     .top
                     .compare_exchange(top.as_ref(), top_node.next.as_ref())
                 {
-                    #[allow(clippy::ignored_unit_patterns)]
-                    Ok(_) => return top,
+                    Ok(()) => return top,
                     Err(actual_top) => top = actual_top,
                 }
             }
@@ -115,8 +113,7 @@ fn test_sorted_linked_list(threads_count: usize, iters_per_thread: usize) {
                         next: next.as_ref().map_or(AtomicArc::default(), AtomicArc::from),
                     });
                     match curr_node.next.compare_exchange(next.as_ref(), Some(&new)) {
-                        #[allow(clippy::ignored_unit_patterns)]
-                        Ok(_) => {
+                        Ok(()) => {
                             if let Some(next_node) = next {
                                 // This is technically incorrect; another node could've been
                                 // inserted, but it's not crucial for this test.


### PR DESCRIPTION
In this pull request there is a review for all the pedantic clippy warnings in this project.

Most of the warnings have been trivially fixed, except for:

1. Error documentation for the `compare_exchange` method of `AtomicArc` and `AtomicWeak`. 0ddb5cef295c02014dca36453d7975a34122ea63
2. The "complex type" of `Vec<(*mut u8, fn(*mut u8))>` in the `Batch` struct: This is a false-warning, the type is not overly complex, this has been noted in the code. bfbc7f4cf4f9a3fdf4653c473ea79d8b399d3a67
3. The missing safety documentation for the trait-function `clone_from_raw`. I've noted this exception in the code with a Todo. c1a6999cf45fa5c6d61789536cd3ec9d2b65a1cc

This pull request is ready to review:

Please take special attention to: 0ddb5cef295c02014dca36453d7975a34122ea63

Please advise for an updated wording for the documentation of these methods.

Kind Regards,
Cameron.